### PR TITLE
Complete the change 'Depend upon po6 v 0.2, not 0.2.1.'

### DIFF
--- a/libe.pc.in
+++ b/libe.pc.in
@@ -7,6 +7,6 @@ Name: libe
 Description: C++ systems-building utilities
 Version: @VERSION@
 
-Requires: libpo6 >= 0.2.1
+Requires: libpo6 >= 0.2
 Libs: -L${libdir} -le
 Cflags: -I${includedir}


### PR DESCRIPTION
Summary:
In the change a3e3b2a, PKG_CHECK_MODULES is updated. However, libe.pc also need to update.
