### PR TITLE
Support creating std::string from slice

### DIFF
--- a/e/slice.h
+++ b/e/slice.h
@@ -59,6 +59,7 @@ class slice
         const uint8_t* data() const { return m_data; }
         const char* cdata() const { return reinterpret_cast<const char*>(m_data); }
         const char* c_str() const { return reinterpret_cast<const char*>(m_data); }
+        std::string str() const { return std::string(cdata(), size()); }
         bool empty() const { return m_sz == 0; }
         std::string hex() const;
         size_t size() const { return m_sz; }


### PR DESCRIPTION
If I do std::string str(slice.c_str()) I don't get a proper string for some reason. It seems like the c string is missing NULL termination. I assume that is on purpose?

The only way to create a proper std::string is as shown in this commit. This should be part of e so people don't get it wrong.
